### PR TITLE
Adding mailer to corporate assistant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["corporate-assistant", "record", "github-crawler"]
+members = ["corporate-assistant", "record", "github-crawler", "mailer"]

--- a/mailer/Cargo.toml
+++ b/mailer/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mailer"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+lettre = "0.9.6"
+lettre_email = "0.9"
+native-tls = "0.2.7"

--- a/mailer/src/lib.rs
+++ b/mailer/src/lib.rs
@@ -1,0 +1,71 @@
+//extern crate native_tls;
+
+use lettre::{
+    smtp::authentication::Credentials, smtp::authentication::Mechanism, ClientSecurity,
+    ClientTlsParameters, SmtpClient, Transport,
+};
+
+use lettre_email::EmailBuilder;
+
+use native_tls::{Protocol, TlsConnector};
+
+pub struct Email {
+    email: lettre_email::Email,
+}
+
+pub struct Client {
+    login: String,
+    password: String,
+    server: String,
+    port: u16,
+}
+
+impl Client {
+    pub fn new(login: &str, password: &str, server: &str, port: u16) -> Client {
+        Client {
+            login: login.to_string(),
+            password: password.to_string(),
+            server: server.to_string(),
+            port: port,
+        }
+    }
+}
+
+impl Email {
+    pub fn new(from: &str, to: &str, subject: &str, body: &str) -> Email {
+        let email = EmailBuilder::new()
+            .from(from)
+            .to(to)
+            .subject(subject)
+            .text(body)
+            .build()
+            .unwrap();
+
+        Email { email: email }
+    }
+
+    pub fn send(&self, client: &Client) {
+        let mut tls_builder = TlsConnector::builder();
+
+        tls_builder.min_protocol_version(Some(Protocol::Tlsv12));
+        let tls_parameters =
+            ClientTlsParameters::new(client.server.clone(), tls_builder.build().unwrap());
+
+        let smtp_credentials = Credentials::new(client.login.clone(), client.password.clone());
+
+        let mut mailer = SmtpClient::new(
+            (client.server.clone(), client.port),
+            ClientSecurity::Required(tls_parameters),
+        )
+        .unwrap()
+        .authentication_mechanism(Mechanism::Plain)
+        .credentials(smtp_credentials)
+        .transport();
+
+        match mailer.send(self.email.clone().into()) {
+            Ok(_) => (),
+            Err(e) => println!("Error {:?}", e),
+        }
+        mailer.close();
+    }
+}

--- a/mailer/src/main.rs
+++ b/mailer/src/main.rs
@@ -1,0 +1,56 @@
+pub use mailer::{Client, Email};
+use std::env;
+
+fn parse_cmdline() -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<u16>,
+    Option<String>,
+    Option<String>,
+) {
+    let mut from: Option<String> = None;
+    let mut to: Option<String> = None;
+    let mut server: Option<String> = None;
+    let mut port: Option<u16> = None;
+    let mut login: Option<String> = None;
+    let mut password: Option<String> = None;
+
+    for arg in env::args() {
+        if arg.starts_with("--") {
+            let trimmed = arg.trim_start_matches("--");
+            let split: Vec<_> = trimmed.split("=").collect();
+            let key = split[0];
+
+            match key {
+                "from" => from = Some(String::from(split[1])),
+                "to" => to = Some(String::from(split[1])),
+                "server" => server = Some(String::from(split[1])),
+                "port" => port = Some(String::from(split[1]).parse().expect("Not a number")),
+                "login" => login = Some(String::from(split[1])),
+                "password" => password = Some(String::from(split[1])),
+                _ => (),
+            }
+        }
+    }
+
+    (from, to, server, port, login, password)
+}
+
+fn main() {
+    let (from, to, server, port, login, password) = parse_cmdline();
+    let client = Client::new(
+        &login.expect("Incorrect login"),
+        &password.expect("Incorrect password"),
+        &server.expect("Incorrect server"),
+        port.expect("Incorrect port"),
+    );
+    let email = Email::new(
+        &from.expect("Incorrect source email address"),
+        &to.expect("Incorrect destination email address"),
+        "Test Rusta",
+        "Test",
+    );
+
+    email.send(&client);
+}


### PR DESCRIPTION
This PR adds smtp mailer implementation to the corporate assistant.

The application, for testing purposes, takes the following parameters:
- `to` - destination email address
- `from`- source email address
- `server` - server address
- `port` - port number
- `login` - login to the server
- `password`.

Exemplary call of the application:
`--from=jan.kos@intel.com --to=jan.kos@gmail.com --server=smtpauth.intel.com --port=587 --password=pswrd --login=jkos`