### PR TITLE
Fixed to multiline script

### DIFF
--- a/custom_action/src/lib.rs
+++ b/custom_action/src/lib.rs
@@ -258,9 +258,9 @@ impl MyApp {
 
         let mut content_to_append: String = "\n[[custom_actions]]\n phrase = \"".to_string();
         content_to_append += &self.te.buffer().unwrap().text().trim();
-        content_to_append += "\"\n script = \"\"\"";
+        content_to_append += "\"\n script = \'\'\'";
         content_to_append += &self.buf.text();
-        content_to_append += "\"\"\"\n";
+        content_to_append += "\'\'\'\n";
         buf.append(&content_to_append);
         buf.save_file(&self.ca_filename)?;
         self.saved = true;
@@ -373,7 +373,7 @@ pub fn action_executor(script: &str) -> bool {
     } else {
         Command::new("bash")
             .arg("-c")
-            .arg("eval ".to_string() + script)
+            .arg(script)
             .output()
             .expect("failed to execute process")
     };
@@ -411,7 +411,9 @@ mod tests {
         let status = action_executor(if cfg!(target_os = "windows") {
             "dir"
         } else {
-            "ls"
+            r####"ls;
+            whoami;
+            date"####
             //"gnome-terminal -- sudo iptraf-ng -g" //Network monitoring
         });
         assert_eq!(status, true);

--- a/run-test-linux.sh
+++ b/run-test-linux.sh
@@ -3,5 +3,5 @@ MODEL=/home/jczaja/DEEPSPEECH/jacek-04-02-2021.pbmm
 SCORER=/home/jczaja/DEEPSPEECH/deepspeech-0.9.3-models.scorer
 SCRIPT_DIR=$(dirname "$0")
 pushd "$SCRIPT_DIR"
-LIBRARY_PATH=/home/jczaja/DEEPSPEECH/deepspeech-native LD_LIBRARY_PATH=/home/jczaja/DEEPSPEECH/deepspeech-native cargo test -- --show-output $1 
+LIBRARY_PATH=/home/jczaja/DEEPSPEECH/deepspeech-native LD_LIBRARY_PATH=/home/jczaja/DEEPSPEECH/deepspeech-native cargo test -- $1  --nocapture 
 popd


### PR DESCRIPTION
This PR is changing a custom script to be wrapped into multiline string e.g """  into being wrapped by mulitline literal strings e.g. '''
That way escaping are not interpreted 