### PR TITLE
Update lettre to 0.10.0-rc.4

### DIFF
--- a/mailer/Cargo.toml
+++ b/mailer/Cargo.toml
@@ -8,6 +8,5 @@ edition = "2018"
 [dependencies]
 #tokio = { version = "1", features = ["full"] }
 tokio = { version = "^1.0", features = ["full"] }
-lettre = "0.9.6"
-lettre_email = "0.9"
+lettre = "0.10.0-rc.4"
 native-tls = "0.2.7"

--- a/mailer/src/lib.rs
+++ b/mailer/src/lib.rs
@@ -1,16 +1,11 @@
 //extern crate native_tls;
 
-use lettre::{
-    smtp::authentication::Credentials, smtp::authentication::Mechanism, ClientSecurity,
-    ClientTlsParameters, SmtpClient, Transport,
-};
-
-use lettre_email::EmailBuilder;
+use lettre::{transport::smtp::authentication::Credentials, Message, SmtpTransport, Transport};
 
 use native_tls::{Protocol, TlsConnector};
 
 pub struct Email {
-    email: lettre_email::Email,
+    email: Message,
 }
 
 pub struct Client {
@@ -33,39 +28,27 @@ impl Client {
 
 impl Email {
     pub fn new(from: &str, to: &str, subject: &str, body: &str) -> Email {
-        let email = EmailBuilder::new()
-            .from(from)
-            .to(to)
+        let email = Message::builder()
+            .from(from.parse().unwrap())
+            .to(to.parse().unwrap())
             .subject(subject)
-            .text(body)
-            .build()
+            .body(String::from(body))
             .unwrap();
 
         Email { email: email }
     }
 
     pub fn send(&self, client: &Client) {
-        let mut tls_builder = TlsConnector::builder();
-
-        tls_builder.min_protocol_version(Some(Protocol::Tlsv12));
-        let tls_parameters =
-            ClientTlsParameters::new(client.server.clone(), tls_builder.build().unwrap());
-
         let smtp_credentials = Credentials::new(client.login.clone(), client.password.clone());
 
-        let mut mailer = SmtpClient::new(
-            (client.server.clone(), client.port),
-            ClientSecurity::Required(tls_parameters),
-        )
-        .unwrap()
-        .authentication_mechanism(Mechanism::Plain)
-        .credentials(smtp_credentials)
-        .transport();
+        let mut mailer = SmtpTransport::relay(&client.server)
+            .unwrap()
+            .credentials(smtp_credentials)
+            .build();
 
-        match mailer.send(self.email.clone().into()) {
+        match mailer.send(&self.email) {
             Ok(_) => (),
             Err(e) => println!("Error {:?}", e),
         }
-        mailer.close();
     }
 }


### PR DESCRIPTION
This PR updates mailer to version 0.10.0-rc.4 of lettre.
This change was introduced to make corporate-assistant work with gmail account.