### PR TITLE
Email config in organization config file

### DIFF
--- a/corporate-assistant/src/config.rs
+++ b/corporate-assistant/src/config.rs
@@ -13,7 +13,15 @@ pub mod configuration {
         config_dir: PathBuf,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Debug)]
+    pub struct EmailConfig {
+        pub server: String,
+        pub port: u16,
+        pub from: String,
+        pub to: String,
+    }
+
+    #[derive(Deserialize, Debug)]
     pub struct OrganizationConfig {
         pub restaurants: Option<Vec<String>>,
         pub recognition: Option<Vec<String>>,
@@ -21,6 +29,7 @@ pub mod configuration {
         pub proxy: Option<Vec<String>>,
         pub jira: Option<Vec<String>>,
         pub home_work_train_stations: Option<Vec<String>>,
+        pub email: Option<EmailConfig>,
     }
 
     impl CAConfig {

--- a/corporate-assistant/src/main.rs
+++ b/corporate-assistant/src/main.rs
@@ -150,6 +150,8 @@ fn main() {
         None => (),
     }
 
+    let email_config = &org_info.email.unwrap();
+
     intents
         .register_action(
             vec![
@@ -162,6 +164,7 @@ fn main() {
                 &org_info.proxy,
                 project_config_file,
                 4,
+                &email_config,
             )),
         )
         .expect_and_log("Registration of MSR module failed");
@@ -178,6 +181,7 @@ fn main() {
                 &org_info.proxy,
                 project_config_file,
                 1,
+                &email_config,
             )),
         )
         .expect_and_log("Registration of MSR module failed");


### PR DESCRIPTION
This PR moves and handles email configuration in organization file. Respective issue for the PR is #35.

Organization file contains toml object `[email]` that contains fields `server`, `port`, `from` and `to`. No additional files are needed for further configuration for sending email.